### PR TITLE
Enable send event routing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
   <profiles>
     <!-- Deployment profile (required so these plugins are only used when deploying) -->
     <profile>

--- a/src/main/java/example/CourierClientApp.java
+++ b/src/main/java/example/CourierClientApp.java
@@ -129,6 +129,17 @@ public class CourierClientApp {
         SendEnhancedResponseBody sendEnhancedResponseBodyTimeout = new SendService().sendEnhancedMessage(sendEnhancedRequestBodyTimeout);
         System.out.println(sendEnhancedResponseBodyTimeout);
 
+	// Event Routing
+	SendEventRoutingRequestBody sendEventRoutingRequestBody = new SendEventRoutingRequestBody();
+	SendEventRoutingRequestRecipient recipient1 = new SendEventRoutingRequestRecipient();
+ 	recipient1.recipient = "unique_recipient_id"
+	recipient1.data = new Gson().fromJson("{'eventName':'user-added', 'status: 'success'}")
+	recipient1.profile = new Gson().fromJson("{'email':'tejas@courier.com'}")	
+	sendEventRoutingRequestBody.recipients.add(recipient)
+	SendEventRoutingResponseBody sendEventRoutingResponse = new SendService().sendEventRouting("user-added", sendEventRoutingRequestBody)
+	System.out.println(sendEventRoutingResponse);
+
+
         /*
         Messages API
          */

--- a/src/main/java/models/SendEventRoutingRequestBody.java
+++ b/src/main/java/models/SendEventRoutingRequestBody.java
@@ -1,0 +1,14 @@
+package models;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class SendEventRoutingRequestBody {
+    private List<SendEventRoutingRequestRecipient> recipients;
+}

--- a/src/main/java/models/SendEventRoutingRequestRecipient.java
+++ b/src/main/java/models/SendEventRoutingRequestRecipient.java
@@ -1,0 +1,18 @@
+package models;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.HashMap;
+
+@Getter
+@Setter
+@ToString
+public class SendEventRoutingRequestRecipient {
+    private String recipient;
+    private HashMap<String, Object> data;
+    private HashMap<String, Object> preferences;
+    private HashMap<String, Object> profile;
+
+}

--- a/src/main/java/models/SendEventRoutingResponseBody.java
+++ b/src/main/java/models/SendEventRoutingResponseBody.java
@@ -1,0 +1,15 @@
+package models;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class SendEventRoutingResponseBody {
+    List<List<SendEventRoutingResponseResult>> results;
+}

--- a/src/main/java/models/SendEventRoutingResponseResult.java
+++ b/src/main/java/models/SendEventRoutingResponseResult.java
@@ -1,0 +1,16 @@
+package models;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+public class SendEventRoutingResponseResult {
+    private String recipient;
+    private HashMap<String, Object> routing;
+}

--- a/src/main/java/services/SendInterface.java
+++ b/src/main/java/services/SendInterface.java
@@ -1,13 +1,10 @@
 package services;
 
-import models.SendEnhancedRequestBody;
-import models.SendEnhancedResponseBody;
-import models.SendListRequestBody;
-import models.SendRequestBody;
-import models.SendResponseBody;
+import models.*;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.Header;
+import retrofit2.http.Path;
 import retrofit2.http.POST;
 
 public interface SendInterface {
@@ -46,5 +43,13 @@ public interface SendInterface {
             @Header("Authorization") String authorization,
             @Header("User-Agent") String userAgent,
             @Header("Idempotency-Key") String idempotencyKey
+    );
+
+    @POST("/send/{event}/routing")
+    Call<SendEventRoutingResponseBody> sendEventRouting(
+            @Path("event") String event,
+            @Body SendEventRoutingRequestBody sendEventRoutingRequestBody,
+            @Header("Authorization") String authorization,
+            @Header("User-Agent") String userAgent
     );
 }

--- a/src/main/java/services/SendInterface.java
+++ b/src/main/java/services/SendInterface.java
@@ -1,6 +1,12 @@
 package services;
 
-import models.*;
+import models.SendEnhancedRequestBody;
+import models.SendEnhancedResponseBody;
+import models.SendEventRoutingRequestBody;
+import models.SendEventRoutingResponseBody;
+import models.SendListRequestBody;
+import models.SendRequestBody;
+import models.SendResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.Header;

--- a/src/main/java/services/SendService.java
+++ b/src/main/java/services/SendService.java
@@ -1,10 +1,6 @@
 package services;
 
-import models.SendEnhancedRequestBody;
-import models.SendEnhancedResponseBody;
-import models.SendListRequestBody;
-import models.SendRequestBody;
-import models.SendResponseBody;
+import models.*;
 
 import java.io.IOException;
 
@@ -66,6 +62,18 @@ public class SendService {
                 Courier.getAuthorizationHeader(),
                 Courier.getUserAgent(),
                 idempotencyKey
+        ).execute().body();
+    }
+
+    public SendEventRoutingResponseBody sendEventRouting(
+            String event,
+            SendEventRoutingRequestBody sendEventRoutingRequestBody
+    ) throws IOException {
+        return sendInterface.sendEventRouting(
+                event,
+                sendEventRoutingRequestBody,
+                Courier.getAuthorizationHeader(),
+                Courier.getUserAgent()
         ).execute().body();
     }
 }

--- a/src/main/java/services/SendService.java
+++ b/src/main/java/services/SendService.java
@@ -1,6 +1,13 @@
 package services;
 
-import models.*;
+import models.SendEnhancedRequestBody;
+import models.SendEnhancedResponseBody;
+import models.SendEventRoutingRequestBody;
+import models.SendEventRoutingResponseBody;
+import models.SendListRequestBody;
+import models.SendRequestBody;
+import models.SendResponseBody;
+
 
 import java.io.IOException;
 


### PR DESCRIPTION
## Description of the change

This PR updates the SendInterface and its implementation in order to make calls to the /send/:event/routing endpoint. It adds request and response model classes in order to make requests via the SDK. I've added an example to the `CourierClientApp` class. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
