### PR TITLE
Resolve jackson-databind dependency CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
     api 'com.squareup.okhttp3:okhttp:4.12.0'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.12.3'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'


### PR DESCRIPTION
`com.fasterxml.jackson.core:jackson-databind` version 2.13.0 is [subject to a CVE](https://nvd.nist.gov/vuln/detail/CVE-2020-36518#range-12157588) with CVSS 7.5 (high).

Updated version to latest available (2.17.2) which is non-breaking as jackson-databind follows semver.

Not sure if build.gradle is auto-generated; if so would be grateful if the dependency could be updated upstream.